### PR TITLE
Support for containers 0.4.2.1

### DIFF
--- a/HTF.cabal
+++ b/HTF.cabal
@@ -153,7 +153,7 @@ Library
                     QuickCheck >= 2.3,
                     base == 4.*,
                     random >= 1.0,
-                    containers >= 0.5,
+                    containers >= 0.4.2.1,
                     process >= 1.0,
                     directory >= 1.0,
                     mtl >= 1.1 && < 2.2,

--- a/Test/Framework/XmlOutput.hs
+++ b/Test/Framework/XmlOutput.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {- |
 
 See <http://pzolee.blogs.balabit.com/2012/11/jenkins-vs-junit-xml-format/>
@@ -16,7 +17,11 @@ module Test.Framework.XmlOutput (
 
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.List as List
+#if MIN_VERSION_containers(0,5,0)
 import qualified Data.Map.Strict as Map
+#else
+import qualified Data.Map as Map
+#endif
 import qualified Data.Text as T
 import Text.Printf
 


### PR DESCRIPTION
Just some simple conditional compilation. The advantage of this is that HTF can be compiled with the version of containers that ships with GHC 7.4.
