### PR TITLE
Resolved compile error with HUnit == 1.3.0.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* 0.12.2.5 (2015-08-21)
+  - resolved compile error with HUnit == 1.3.0.0
+
 * 0.12.2.3 (2014-10-27)
   - fixed another lexing bug (issue #45)
 

--- a/HTF.cabal
+++ b/HTF.cabal
@@ -1,5 +1,5 @@
 Name:             HTF
-Version:          0.12.2.4
+Version:          0.12.2.5
 License:          LGPL
 License-File:     LICENSE
 Copyright:        (c) 2005-2014 Stefan Wehr

--- a/Test/Framework/Preprocessor.hs
+++ b/Test/Framework/Preprocessor.hs
@@ -36,7 +36,7 @@ import Language.Preprocessor.Cpphs ( runCpphs,
                                      BoolOptions(..),
                                      defaultCpphsOptions)
 import System.IO ( hPutStrLn, stderr )
-import Test.HUnit hiding (State)
+import Test.HUnit hiding (State, Location)
 import Control.Monad.State.Strict
 import qualified Data.List as List
 import Data.Maybe


### PR DESCRIPTION
Hi Stefan,

HTF was not compiling any more with HUnit-1.3.0.0, e.g.

Excerpt from https://travis-ci.org/factisresearch/dockercook/jobs/76642230:

Test/Framework/Preprocessor.hs:446:31:
    Ambiguous occurrence `Location'
    It could refer to either `Test.HUnit.Location',
                             imported from `Test.HUnit' at Test/Framework/Preprocessor.hs:46:1-32
                             (and originally defined in `Test.HUnit.Lang')
                          or `Test.Framework.Location.Location',
                             imported from `Test.Framework.Location' at Test/Framework/Preprocessor.hs:51:1-30
                             (and originally defined at Test/Framework/Location.hs:37:6-13)

Best,
Emin