### PR TITLE
Add command line option `--shuffle=BOOL`.

### DIFF
--- a/tests/TestHTF.hs
+++ b/tests/TestHTF.hs
@@ -421,7 +421,7 @@ main =
          _ ->
              do withSystemTempFile "HTF-out" $ \outFile h ->
                   do hClose h
-                     ecode <- runTestWithArgs ["-j4", "--deterministic",
+                     ecode <- runTestWithArgs ["-j4", "--shuffle=false",
                                                "--json", "--output-file=" ++ outFile] tests
                      case ecode of
                        ExitFailure _ -> checkOutput outFile


### PR DESCRIPTION
`--shuffle=true` randomizes the test order (in the parallel as well as in
sequential case)

This interferes with `--deterministic`:
    * `--shuffle=true --deterministic` -> No shuffling
    * `--deterministic --shuffle=true` -> shuffling

That means the last option precedes.