### PR TITLE
Add type class WrappableHTF.

### DIFF
--- a/Test/Framework.hs
+++ b/Test/Framework.hs
@@ -37,7 +37,8 @@ module Test.Framework (
   module Test.Framework.AssertM,
 
   -- * Organizing tests
-  TM.makeTestSuite, TM.TestSuite, TM.htfMain, TM.htfMainWithArgs, Loc.makeLoc, TM.runTest
+  TM.makeTestSuite, TM.TestSuite, TM.htfMain, TM.htfMainWithArgs, Loc.makeLoc, TM.runTest,
+  TM.WrappableHTF(..)
 
 ) where
 

--- a/Test/Framework/TestManager.hs
+++ b/Test/Framework/TestManager.hs
@@ -106,6 +106,14 @@ addToTestSuite :: TestSuite -> [Test] -> TestSuite
 addToTestSuite (TestSuite id ts) ts' = TestSuite id (ts ++ ts')
 addToTestSuite (AnonTestSuite ts) ts' = AnonTestSuite (ts ++ ts')
 
+-- | Kind of specialised 'Functor' type class for tests, which allows you to
+-- modify the 'Assertion's of the 'WrappableHTF'-thing without changing any
+-- test code.
+--
+-- E.g. if you want to add timeouts to all tests of a module, you could write:
+--
+-- > addTimeout test = timeout 100 test >>= assertJustVerbose "Timeout exceeded"
+-- > testsWithTimeouts = wrap addTimeout htf_thisModulesTests
 class WrappableHTF t where
     wrap :: (Assertion -> Assertion) -> t -> t
 

--- a/tests/MiscTest.hs
+++ b/tests/MiscTest.hs
@@ -21,10 +21,11 @@ import Test.Framework.History
 import Test.Framework.Preprocessor
 import Test.Framework.PrettyHaskell
 import Test.Framework.HUnitWrapper
+import Test.Framework.TestManager
 import System.Exit
 import Test.HUnit
 
-allTests = historyTests ++ preprocessorTests ++ prettyHaskellTests ++ hunitWrapperTests
+allTests = historyTests ++ preprocessorTests ++ prettyHaskellTests ++ hunitWrapperTests ++ wrappableTests
 
 main :: IO ()
 main =


### PR DESCRIPTION
Sometimes it's handy to wrap a test with a function which asserts that an invariant holds before and after execution of the test. E.g.
```haskell
test_xyz =
    withoutLeakingThreads $
    do assert...
```
, where `withoutLeakingThreads` ensures that the test fails if it doesn't close all of it child threads.

Actually this is a property which should hold true for all tests in my test suites. However it would be annoying to prefix every test with a call to `withoutLeakingThreads`. Therefore it would be nice to have a function like `wrap :: (Assertion -> Assertion) -> TestSuite -> TestSuite`, such that `wrap withoutLeakingThreads mySuite` wraps all tests in `mySuite` with the function `withoutLeakingThreads`.

This PR implements the desired feature by adding a type class `WrappableHTF` without touching anything else of the library.
@skogsbaer If you think this is a good way to go, I'd like to add tests and documentation for the type class.
