### PR TITLE
Add --repeat flag for running each test multiple times

### DIFF
--- a/HTF.cabal
+++ b/HTF.cabal
@@ -237,7 +237,7 @@ Test-Suite TestHTF
   Other-Modules:
     Foo.A, Foo.B, TestHTFHunitBackwardsCompatible, FailFast, MaxCurTime,
     MaxPrevTime, PrevFactor, SortByPrevTime, UniqTests1, UniqTests2, Quasi,
-    Tutorial
+    Tutorial, Repeat
 
 Test-Suite TestThreadPools
   Main-is:           ThreadPoolTest.hs

--- a/Test/Framework/CmdlineOptions.hs
+++ b/Test/Framework/CmdlineOptions.hs
@@ -89,8 +89,9 @@ data CmdlineOptions = CmdlineOptions {
     , opts_sortByPrevTime :: Bool       -- ^ Sort tests by their previous run times (ascending). Default: 'False'
     , opts_maxPrevTimeMs :: Maybe Milliseconds -- ^ Ignore tests with a runtime greater than given in a previous test run.
     , opts_maxCurTimeMs :: Maybe Milliseconds  -- ^ Abort tests that run more than the given milliseconds.
-    , opts_prevFactor :: Maybe Double -- ^ Warn if a test runs more than N times slower than in a previosu run.
+    , opts_prevFactor :: Maybe Double -- ^ Warn if a test runs more than N times slower than in a previous run.
     , opts_timeoutIsSuccess :: Bool -- ^ Do not regard test timeout as an error.
+    , opts_repeat :: Int -- ^ Number of times to repeat a test before reporting it as a success.
     }
 
 {- |
@@ -117,6 +118,7 @@ defaultCmdlineOptions = CmdlineOptions {
     , opts_maxCurTimeMs = Nothing
     , opts_prevFactor = Nothing
     , opts_timeoutIsSuccess = False
+    , opts_repeat = 1
     }
 
 processorCount :: Int
@@ -181,6 +183,10 @@ optionDescriptions =
     , Option []        ["timeout-is-success"]
              (NoArg (\o -> Right $ o { opts_timeoutIsSuccess = True }))
              "Do not regard a test timeout as an error."
+    , Option []        ["repeat"]
+             (ReqArg (\s o -> parseRead "--repeat" s >>= \(i::Int) ->
+                              Right $ o { opts_repeat = i}) "NUMBER")
+             "Execute all tests NUMBER times"
     , Option ['h']     ["help"]
              (NoArg (\o -> Right $ o { opts_help = True }))
              "Display this message."
@@ -301,6 +307,7 @@ testConfigFromCmdlineOptions opts =
                            , tc_maxSingleTestTime = opts_maxCurTimeMs opts
                            , tc_prevFactor = opts_prevFactor opts
                            , tc_timeoutIsSuccess = opts_timeoutIsSuccess opts
+                           , tc_repeat = opts_repeat opts
                            }
     where
 #ifdef mingw32_HOST_OS

--- a/Test/Framework/CmdlineOptions.hs
+++ b/Test/Framework/CmdlineOptions.hs
@@ -91,7 +91,7 @@ data CmdlineOptions = CmdlineOptions {
     , opts_maxCurTimeMs :: Maybe Milliseconds  -- ^ Abort tests that run more than the given milliseconds.
     , opts_prevFactor :: Maybe Double -- ^ Warn if a test runs more than N times slower than in a previous run.
     , opts_timeoutIsSuccess :: Bool -- ^ Do not regard test timeout as an error.
-    , opts_repeat :: Int -- ^ Number of times to repeat a test before reporting it as a success.
+    , opts_repeat :: Int                 -- ^ Number of times to repeat tests selected on the command line before reporting them as a success.
     }
 
 {- |
@@ -186,7 +186,7 @@ optionDescriptions =
     , Option []        ["repeat"]
              (ReqArg (\s o -> parseRead "--repeat" s >>= \(i::Int) ->
                               Right $ o { opts_repeat = i}) "NUMBER")
-             "Execute all tests NUMBER times"
+             "Execute the tests selected on the command line NUMBER times."
     , Option ['h']     ["help"]
              (NoArg (\o -> Right $ o { opts_help = True }))
              "Display this message."

--- a/Test/Framework/TestTypes.hs
+++ b/Test/Framework/TestTypes.hs
@@ -205,7 +205,7 @@ data TestConfig
       , tc_timeoutIsSuccess :: Bool     -- ^ Do not regard timeout as an error
       , tc_maxSingleTestTime :: Maybe Milliseconds -- ^ Maximum time in milliseconds a single test is allowed to run
       , tc_prevFactor :: Maybe Double   -- ^ Maximum factor a single test is allowed to run slower than its previous execution
-      , tc_repeat :: Int -- ^ Number of times to repeat a test before reporting it as a success.
+      , tc_repeat :: Int                -- ^ Number of times to repeat tests selected on the command line before reporting them as a success.
       }
 
 instance Show TestConfig where
@@ -227,6 +227,7 @@ instance Show TestConfig where
         showString ", tc_timeoutIsSuccess=" . showsPrec 1 (tc_timeoutIsSuccess tc) .
         showString ", tc_maxSingleTestTime=" . showsPrec 1 (tc_maxSingleTestTime tc) .
         showString ", tc_prevFactor=" . showsPrec 1 (tc_prevFactor tc) .
+        showString ", tc_repeat=" . showPrec 1 (tc_repeat tc) .
         showString " }"
 
 -- | A 'TestReporter' provides hooks to customize the output of HTF.

--- a/Test/Framework/TestTypes.hs
+++ b/Test/Framework/TestTypes.hs
@@ -205,6 +205,7 @@ data TestConfig
       , tc_timeoutIsSuccess :: Bool     -- ^ Do not regard timeout as an error
       , tc_maxSingleTestTime :: Maybe Milliseconds -- ^ Maximum time in milliseconds a single test is allowed to run
       , tc_prevFactor :: Maybe Double   -- ^ Maximum factor a single test is allowed to run slower than its previous execution
+      , tc_repeat :: Int -- ^ Number of times to repeat a test before reporting it as a success.
       }
 
 instance Show TestConfig where

--- a/Test/Framework/TestTypes.hs
+++ b/Test/Framework/TestTypes.hs
@@ -227,7 +227,7 @@ instance Show TestConfig where
         showString ", tc_timeoutIsSuccess=" . showsPrec 1 (tc_timeoutIsSuccess tc) .
         showString ", tc_maxSingleTestTime=" . showsPrec 1 (tc_maxSingleTestTime tc) .
         showString ", tc_prevFactor=" . showsPrec 1 (tc_prevFactor tc) .
-        showString ", tc_repeat=" . showPrec 1 (tc_repeat tc) .
+        showString ", tc_repeat=" . showsPrec 1 (tc_repeat tc) .
         showString " }"
 
 -- | A 'TestReporter' provides hooks to customize the output of HTF.

--- a/tests/TestHTF.hs
+++ b/tests/TestHTF.hs
@@ -299,7 +299,7 @@ checkOutput output =
                                                                                       ,"line" .= J.toJSON (97+lineOffset)]]]])
     where
       lineOffset :: Int
-      lineOffset = 31
+      lineOffset = 32
       checkStatus tuple@(pass, fail, error, pending, timedOut) json =
           {-
             {"location":null

--- a/tests/TestHTF.hs
+++ b/tests/TestHTF.hs
@@ -61,6 +61,7 @@ import MaxPrevTime
 import UniqTests1
 import UniqTests2
 import PrevFactor
+import Repeat
 import SortByPrevTime
 import Quasi
 
@@ -409,6 +410,7 @@ main =
          "MaxCurTime.hs":rest -> maxCurTimeMain rest
          "MaxPrevTime.hs":rest -> maxPrevTimeMain rest
          "PrevFactor.hs":rest -> prevFactorMain rest
+         "Repeat.hs":rest -> repeatMain rest
          "SortByPrevTime.hs":rest -> sortByPrevTimeMain rest
          "UniqTests1.hs":rest -> uniqTests1Main rest
          "UniqTests2.hs":rest -> uniqTests2Main rest

--- a/tests/real-bbt/Repeat.hs
+++ b/tests/real-bbt/Repeat.hs
@@ -1,0 +1,23 @@
+{-# OPTIONS_GHC -F -pgmF ./scripts/local-htfpp #-}
+module Repeat (repeatMain) where
+
+import Test.Framework
+
+import Data.IORef
+import System.IO.Unsafe
+
+globalBool :: IORef Bool
+globalBool = unsafePerformIO (newIORef True)
+{-# NOINLINE globalBool #-}
+
+readGlobalBool ::  IO Bool
+readGlobalBool =
+    do b <- readIORef globalBool
+       writeIORef globalBool False
+       return b
+
+test_globalMVarIsTrue =
+    do b <- readGlobalBool
+       assertEqual b True
+
+repeatMain args = htfMainWithArgs args htf_thisModulesTests

--- a/tests/real-bbt/Repeat.sh
+++ b/tests/real-bbt/Repeat.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source $(dirname $0)/lib
+
+run_test Repeat.hs --repeat 1
+check_success
+check_counts 1 1 0 0 0 0 0
+
+run_test Repeat.hs --repeat 2
+check_fail
+check_counts 1 0 0 1 0 0 0

--- a/tests/real-bbt/Repeat.sh
+++ b/tests/real-bbt/Repeat.sh
@@ -2,6 +2,8 @@
 
 source $(dirname $0)/lib
 
+rm -f .HTF/TestHTF.history
+
 run_test Repeat.hs --repeat 1
 check_success
 check_counts 1 1 0 0 0 0 0


### PR DESCRIPTION
This resolves #59.

The first patch makes the minimal number of changes to implement this feature. Things that would probably make sense but are not implemented by this patch include:

* Show the repetition number in the error message.
* Save the average or maximum running time of a test in the history.
* Don't do repetitions in one block, instead interspersing other tests.
* Distribute repetitions across test runners.

Please note that on my computer `stack test` fails with these changes. I don't know whether this failure results from my patch as I am having trouble understanding the [test output](https://gist.github.com/timjb/7f696fd4bbcba1409acdff059f9bc6bb).