### PR TITLE
Upper bound on some QuickCheck CPP

### DIFF
--- a/Test/Framework/QuickCheckWrapper.hs
+++ b/Test/Framework/QuickCheckWrapper.hs
@@ -165,7 +165,7 @@ qcAssertion qc =
                       quickCheckTestFail (Just (adjustOutput msg))
                   Right (NoExpectedFailure { output=msg }) ->
                       quickCheckTestFail (Just (adjustOutput msg))
-#if MIN_VERSION_QuickCheck(2,8,0)
+#if MIN_VERSION_QuickCheck(2,8,0) && !MIN_VERSION_QuickCheck(2,12,0)
                   Right (InsufficientCoverage { output=msg }) ->
                       quickCheckTestFail (Just (adjustOutput msg))
 #endif


### PR DESCRIPTION
The `InsufficientCoverage` constructor of `Result` was added in 2.8, then removed in 2.12