### PR TITLE
Initial support for (TeX-style) Literate Haskell

### DIFF
--- a/HTFPP.hs
+++ b/HTFPP.hs
@@ -35,7 +35,7 @@ usage :: IO ()
 usage =
     hPutStrLn stderr
       ("Preprocessor for the Haskell Test Framework\n\n" ++
-       "Usage: " ++ progName ++ " [--hunit|--debug|--version] [FILE1 [FILE2 [FILE3]]]\n\n" ++
+       "Usage: " ++ progName ++ " [--hunit|--debug|--version|--literate-tex] [FILE1 [FILE2 [FILE3]]]\n\n" ++
        "* If no argument is given, input is read from stdin and\n" ++
        "  output is written to stdout.\n" ++
        "* If only FILE1 is given, input is read from this file\n" ++
@@ -47,7 +47,9 @@ usage =
        "  FILE1 serves as the original input filename.\n\n" ++
        "The `--hunit' flag causes assert-like macros to be expanded in a way\n" ++
        "that is backwards-compatible with the corresponding functions of the\n" ++
-       "HUnit library.")
+       "HUnit library.\n" ++
+       "The `--literate-tex` flag causes the additional generated code to be wrapped\n" ++
+       "in TeX-style literate code blocks.")
 
 outputVersion :: IO ()
 outputVersion =
@@ -75,7 +77,8 @@ main =
                exitWith ExitSuccess
        let hunitBackwardsCompat = "--hunit" `elem` args
            debug = "--debug" `elem` args
-           restArgs = flip filter args $ \x -> x /= "--hunit" && x /= "--debug"
+           literateTex = "--literate-tex" `elem` args
+           restArgs = flip filter args $ \x -> not $ x `elem` ["--hunit", "--debug", "--literate-tex"]
        (origInputFilename, hIn, hOut) <-
            case restArgs of
              [] ->
@@ -96,7 +99,7 @@ main =
                     usage
                     exitWith (ExitFailure 1)
        input <- hGetContents hIn
-       output <- transform hunitBackwardsCompat debug origInputFilename input `catch`
+       output <- transform hunitBackwardsCompat debug literateTex rigInputFilename input `catch`
                    (\ (e::SomeException) ->
                         do hPutStrLn stderr (progName ++
                                              ": unexpected exception: " ++

--- a/HTFPP.hs
+++ b/HTFPP.hs
@@ -75,9 +75,9 @@ main =
        when ("--version" `elem` args) $
             do outputVersion
                exitWith ExitSuccess
-       let hunitBackwardsCompat = "--hunit" `elem` args
-           debug = "--debug" `elem` args
-           literateTex = "--literate-tex" `elem` args
+       let transformOpts = TransformOptions { hunitBackwardsCompat = "--hunit" `elem` args
+                                            , debug = "--debug" `elem` args
+                                            , literateTex = "--literate-tex" `elem` args }
            restArgs = flip filter args $ \x -> not $ x `elem` ["--hunit", "--debug", "--literate-tex"]
        (origInputFilename, hIn, hOut) <-
            case restArgs of
@@ -99,7 +99,7 @@ main =
                     usage
                     exitWith (ExitFailure 1)
        input <- hGetContents hIn
-       output <- transform hunitBackwardsCompat debug literateTex rigInputFilename input `catch`
+       output <- transform transformOpts origInputFilename input `catch`
                    (\ (e::SomeException) ->
                         do hPutStrLn stderr (progName ++
                                              ": unexpected exception: " ++

--- a/Test/Framework/Preprocessor.hs
+++ b/Test/Framework/Preprocessor.hs
@@ -24,7 +24,7 @@
 
 module Test.Framework.Preprocessor (
 
-    transform, progName, preprocessorTests
+    transform, progName, preprocessorTests, TransformOptions(..)
 
 ) where
 
@@ -396,8 +396,12 @@ cpphsOptions =
       boolopts = (boolopts defaultCpphsOptions) { lang = True } -- lex as haskell
     }
 
-transform :: Bool -> Bool -> Bool -> FilePath -> String -> IO String
-transform hunitBackwardsCompat debug literateTex originalFileName input =
+data TransformOptions = TransformOptions { hunitBackwardsCompat :: Bool
+                                         , debug :: Bool
+                                         , literateTex :: Bool }
+
+transform :: TransformOptions -> FilePath -> String -> IO String
+transform (TransformOptions hunitBackwardsCompat debug literateTex) originalFileName input =
     do (info, toks, pass1) <- analyze originalFileName fixedInput
        preprocess info toks pass1
     where

--- a/Test/Framework/Preprocessor.hs
+++ b/Test/Framework/Preprocessor.hs
@@ -396,8 +396,8 @@ cpphsOptions =
       boolopts = (boolopts defaultCpphsOptions) { lang = True } -- lex as haskell
     }
 
-transform :: Bool -> Bool -> FilePath -> String -> IO String
-transform hunitBackwardsCompat debug originalFileName input =
+transform :: Bool -> Bool -> Bool -> FilePath -> String -> IO String
+transform hunitBackwardsCompat debug literateTex originalFileName input =
     do (info, toks, pass1) <- analyze originalFileName fixedInput
        preprocess info toks pass1
     where
@@ -408,7 +408,7 @@ transform hunitBackwardsCompat debug originalFileName input =
              let opts = mkOptionsForModule info
              preProcessedInput <-
                  runCpphsPass2 (boolopts opts) (defines opts) originalFileName pass1
-             return $ preProcessedInput ++ "\n\n" ++ additionalCode info ++ "\n"
+             return $ preProcessedInput ++ "\n\n" ++ possiblyWrap literateTex (additionalCode info) ++ "\n"
       -- fixedInput serves two purposes:
       -- 1. add a trailing \n
       -- 2. turn lines of the form '# <number> "<filename>"' into line directives '#line <number> <filename>'
@@ -428,6 +428,8 @@ transform hunitBackwardsCompat debug originalFileName input =
                                     nameDefines info
                               , boolopts = (boolopts defaultCpphsOptions) { lang = True } -- lex as haskell
                               }
+      possiblyWrap :: Bool -> String -> String
+      possiblyWrap b s = if b then "\\begin{code}\n" ++ s ++ "\\end{code}" else s
       additionalCode :: ModuleInfo -> String
       additionalCode info =
           thisModulesTestsFullName (mi_moduleNameWithDefault info) ++ " :: " ++


### PR DESCRIPTION
Add a new option flag `--literate-tex` and pass it's presence down the
call stack to `transform`. When present, wrap the additional generated
code in a pair of `\begin{code}` and `\end{code}` delimiters.

`literate-tex` rather than just `literate` to allow for future support for Bird-style literate files too.