### PR TITLE
Address warning noncanonical-monad-instances

### DIFF
--- a/HTF.cabal
+++ b/HTF.cabal
@@ -180,7 +180,9 @@ Library
     Paths_HTF
   Build-tool-depends: cpphs:cpphs >= 1.19
   Default-language:  Haskell2010
-  Ghc-Options: -W -fwarn-unused-imports -fwarn-unused-binds -fwarn-unused-matches -fwarn-unused-do-bind -fwarn-wrong-do-bind
+  Ghc-Options:
+    -W -fwarn-unused-imports -fwarn-unused-binds -fwarn-unused-matches -fwarn-unused-do-bind -fwarn-wrong-do-bind
+    -Wcompat
 
 Test-Suite MiscTests
   Main-is:           MiscTest.hs

--- a/HTF.cabal
+++ b/HTF.cabal
@@ -86,12 +86,13 @@ Extra-Source-Files:
   scripts/prepare
 
 tested-with:
-  GHC == 8.2.2
-  GHC == 8.4.4
-  GHC == 8.6.5
+  GHC == 9.2.1
+  GHC == 9.0.2
+  GHC == 8.10.7
   GHC == 8.8.4
-  GHC == 8.10.4
-  GHC == 9.0.1
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
 
 Source-Repository head
   Type:           git

--- a/HTF.cabal
+++ b/HTF.cabal
@@ -1,3 +1,4 @@
+Cabal-Version:    2.0
 Name:             HTF
 Version:          0.14.0.6
 License:          LGPL-2.1
@@ -31,7 +32,7 @@ Description:
     demonstrating HTF's coloring, pretty-printing and diff functionality.
 
 Build-Type:       Custom
-Cabal-Version:    2.0
+
 Extra-Source-Files:
   README.md
   TODO.org
@@ -99,18 +100,18 @@ Source-Repository head
 Custom-Setup
   Setup-Depends:   base >= 4.10 && < 5,
                    process,
-                   Cabal
+                   Cabal < 4
 
 Executable htfpp
   Main-Is:          HTFPP.hs
   Build-Depends:    HUnit,
                     array,
-                    base >= 4.10 && < 5,
-                    cpphs >= 1.19,
-                    directory >= 1.0,
-                    mtl >= 1.1,
-                    old-time >= 1.0,
-                    random >= 1.0,
+                    base,
+                    cpphs,
+                    directory,
+                    mtl,
+                    old-time,
+                    random,
                     text,
                     HTF
   Build-tool-depends: cpphs:cpphs >= 1.19
@@ -187,7 +188,7 @@ Test-Suite MiscTests
   Hs-Source-Dirs:    tests
   Build-depends:     HTF,
                      HUnit,
-                     base >= 4.10 && < 5,
+                     base,
                      mtl,
                      random
   Build-tool-depends: HTF:htfpp
@@ -198,18 +199,18 @@ Test-Suite TestHTF
   Hs-Source-Dirs:    tests, tests/real-bbt
   Type:              exitcode-stdio-1.0
   Build-depends:     HTF,
-                     aeson >= 0.6,
+                     aeson,
                      aeson-pretty,
-                     base >= 4.10 && < 5,
-                     bytestring >= 0.9,
-                     directory >= 1.0,
+                     base,
+                     bytestring,
+                     directory,
                      filepath >= 1.1,
-                     process >= 1.0,
+                     process,
                      random,
-                     regex-compat >= 0.92,
+                     regex-compat,
                      template-haskell,
                      temporary >= 1.1,
-                     text >= 0.11,
+                     text,
                      unordered-containers >= 0.2
   Build-tool-depends: HTF:htfpp
   Default-language:  Haskell2010
@@ -223,7 +224,7 @@ Test-Suite TestThreadPools
   Type:              exitcode-stdio-1.0
   Hs-Source-Dirs:    tests
   Build-depends:     HTF,
-                     base >= 4.10 && < 5,
+                     base,
                      mtl,
                      random
   Build-tool-depends: HTF:htfpp

--- a/Test/Framework/AssertM.hs
+++ b/Test/Framework/AssertM.hs
@@ -48,11 +48,11 @@ instance Functor AssertBool where
     fmap = liftM
 
 instance Applicative AssertBool where
-    pure  = return
+    pure  = AssertOk
     (<*>) = ap
 
 instance Monad AssertBool where
-    return = AssertOk
+    return = pure
     AssertFailed stack >>= _ = AssertFailed stack
     AssertOk x >>= k = k x
 #if !(MIN_VERSION_base(4,13,0))


### PR DESCRIPTION
- Address warning `noncanonical-monad-instances`.
- Remove redundant version constraints of dependencies.
- Updated GHC range in tested-with field.
- Upper bound on `Cabal` to satisfy `cabal check`.