### PR TITLE
Adapt to removal of Control.Monad re-exports in mtl-2.3

### DIFF
--- a/Test/Framework/TestReporter.hs
+++ b/Test/Framework/TestReporter.hs
@@ -39,6 +39,7 @@ import Test.Framework.JsonOutput
 import Test.Framework.XmlOutput
 
 import System.IO
+import Control.Monad
 import Control.Monad.RWS
 import Text.PrettyPrint
 


### PR DESCRIPTION
I've tested that everything builds.