### PR TITLE
Fix `extra-source-files` to make `cabal sdist` work

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "HTF_TEST_STACK_YAML=$GITHUB_WORKSPACE/stack-${{ matrix.compiler }}.yaml" >> "$GITHUB_ENV"
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Permissions bug workaround
         run: "chown -R $(id -un):$(id -gn) ~"
       - name: Compute cache key
@@ -41,7 +41,7 @@ jobs:
           echo "HTF_CACHE_KEY=$HTF_CACHE_KEY" >> "$GITHUB_ENV"
           echo "HTF_CACHE_KEY=$HTF_CACHE_KEY"
       - name: Cache stack dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.stack

--- a/HTF.cabal
+++ b/HTF.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:    2.0
 Name:             HTF
-Version:          0.15.0.0
+Version:          0.15.0.1
 License:          LGPL-2.1
 License-File:     LICENSE
 Copyright:        (c) 2005-2015 Stefan Wehr
@@ -89,7 +89,8 @@ Extra-Source-Files:
   scripts/prepare
 
 tested-with:
-  GHC == 9.2.1
+  GHC == 9.4.4
+  GHC == 9.2.6
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4

--- a/HTF.cabal
+++ b/HTF.cabal
@@ -38,15 +38,16 @@ Build-Type:       Custom
 
 Extra-Source-Files:
   README.md
-  TODO.org
   ChangeLog
-  .travis.yml
   stack.yaml
-  stack-ghc-8.0.yaml
   stack-ghc-8.2.yaml
   stack-ghc-8.4.yaml
   stack-ghc-8.6.yaml
   stack-ghc-8.8.yaml
+  stack-ghc-8.10.yaml
+  stack-ghc-9.0.yaml
+  stack-ghc-9.2.yaml
+  stack-ghc-9.4.yaml
   tests/bbt/should_fail/BBTArgs
   tests/bbt/should_fail/*.err
   tests/bbt/should_fail/*.out

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,13 +7,13 @@ packages:
 - completed:
     hackage: haskell-src-1.0.3.1@sha256:4f17c7a8c3989cbbe5a07facf7ee1080c7688c33fd6e8b8d8c9693a2d96726d2,1680
     pantry-tree:
-      size: 621
       sha256: 1ad12f023a5c4c4f3053f15519355166f1a6eb05ec639d7b32f8fcd587e28bea
+      size: 621
   original:
     hackage: haskell-src-1.0.3.1
 snapshots:
 - completed:
-    size: 532177
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/20.yaml
-    sha256: 0e14ba5603f01e8496e8984fd84b545a012ca723f51a098c6c9d3694e404dc6d
-  original: lts-16.20
+    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
+    size: 534126
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
+  original: lts-16.31


### PR DESCRIPTION
- `HTF.cabal` mentions non-existing file `.travis.yml`, makes `cabal sdist` fail.
- update list of `stack-ghc-*.yaml` files in `extra-source-files`
- Bump actions in CI to latest
- Bump version to 0.15.0.1