### PR TITLE
Tutorial: Fix Main.hs example compilation error

### DIFF
--- a/Test/Framework/Tutorial.hs
+++ b/Test/Framework/Tutorial.hs
@@ -79,6 +79,8 @@ Your main module collecting all tests should look like this:
 &#x7b;-&#x23; OPTIONS_GHC -F -pgmF htfpp &#x23;-&#x7d;
 module Main ( main ) where
 
+import Test.Framework
+
 -- Import modules defining HTF tests like this:
 import &#x7b;-&#x40; HTF_TESTS &#x40;-&#x7d; MyModule
 


### PR DESCRIPTION
Fixes the following compilation error:

 Main.hs:11:30: error: [GHC-76037]
     Not in scope: type constructor or class ‘Test.Framework.TestSuite’
     NB: no module named ‘Test.Framework’ is imported.