### PR TITLE
replace old-time with time in `measure` from Test.Framework.Utils

### DIFF
--- a/HTF.cabal
+++ b/HTF.cabal
@@ -112,9 +112,9 @@ Executable htfpp
                     cpphs >= 1.19,
                     directory >= 1.0,
                     mtl >= 1.1,
-                    old-time >= 1.0,
                     random >= 1.0,
                     text >= 0.11,
+                    time >= 1.8 && < 1.15,
                     HTF
   Build-tool-depends: cpphs:cpphs >= 1.19
   Other-Modules:
@@ -141,12 +141,12 @@ Library
                     lifted-base >= 0.1,
                     monad-control >= 0.3,
                     mtl >= 1.1,
-                    old-time >= 1.0,
                     pretty >= 1.0,
                     process >= 1.0,
                     random >= 1.0,
                     regex-compat >= 0.92,
                     text >= 0.11,
+                    time >= 1.8 && < 1.15,
                     time,
                     vector,
                     xmlgen >= 0.6

--- a/Test/Framework/Utils.hs
+++ b/Test/Framework/Utils.hs
@@ -22,7 +22,7 @@ module Test.Framework.Utils where
 
 import System.Directory
 import Data.Char
-import System.Time hiding (diffClockTimes)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import System.Random
 import Data.Array.IO
 import Control.Monad
@@ -143,20 +143,15 @@ strip = reverse . dropWhile isSpace . reverse . dropWhile isSpace
 -- Measures execution time of the given IO action in milliseconds
 measure :: IO a -> IO (a, Int)
 measure ma =
-    do t0 <- getClockTime
+    do t0 <- getMicroTime
        a <- ma
-       t1 <- a `seq` getClockTime
-       let diffMicro = t1 `diffClockTimes` t0
+       t1 <- a `seq` getMicroTime
+       let diffMicro = t1 - t0
        return (a, fromInteger (diffMicro `div` 1000))
 
-diffClockTimes :: ClockTime -> ClockTime -> Integer
-diffClockTimes (TOD s1 p1) (TOD s0 p0) =
-    (picoseconds p1 + seconds s1) -
-    (picoseconds p0 + seconds s0)
-    where
-      -- bring all into microseconds
-      picoseconds i = i `div` (1000 * 1000)
-      seconds i = i * 1000000
+getMicroTime :: IO Integer
+getMicroTime =
+    floor . (* 1000000) <$> getPOSIXTime
 
 -- | Randomly shuffle a list
 --   /O(N)/


### PR DESCRIPTION
This replace [deprecated old-time](https://hackage.haskell.org/package/old-time) with `time` as hackage suggests:
> Deprecated in favor of [time](https://hackage.haskell.org/package/time)

Tested with: `stack test`