### PR TITLE
Replace getPOSIXTime with getMonotonicTimeNSec

### DIFF
--- a/HTF.cabal
+++ b/HTF.cabal
@@ -131,7 +131,7 @@ Library
                     QuickCheck >= 2.3,
                     aeson >= 0.11,
                     array,
-                    base >= 4.10 && < 5,
+                    base >= 4.11 && < 5,
                     base64-bytestring,
                     bytestring >= 0.9,
                     containers >= 0.5,
@@ -146,7 +146,6 @@ Library
                     random >= 1.0,
                     regex-compat >= 0.92,
                     text >= 0.11,
-                    time >= 1.8 && < 1.15,
                     time,
                     vector,
                     xmlgen >= 0.6

--- a/HTF.cabal
+++ b/HTF.cabal
@@ -131,7 +131,7 @@ Library
                     QuickCheck >= 2.3,
                     aeson >= 0.11,
                     array,
-                    base >= 4.11 && < 5,
+                    base >= 4.10 && < 5,
                     base64-bytestring,
                     bytestring >= 0.9,
                     containers >= 0.5,

--- a/Test/Framework/Utils.hs
+++ b/Test/Framework/Utils.hs
@@ -22,7 +22,7 @@ module Test.Framework.Utils where
 
 import System.Directory
 import Data.Char
-import Data.Time.Clock.POSIX (getPOSIXTime)
+import GHC.Clock (getMonotonicTimeNSec)
 import System.Random
 import Data.Array.IO
 import Control.Monad
@@ -150,8 +150,7 @@ measure ma =
        return (a, fromInteger (diffMicro `div` 1000))
 
 getMicroTime :: IO Integer
-getMicroTime =
-    floor . (* 1000000) <$> getPOSIXTime
+getMicroTime = (`div` 1000) . fromIntegral <$> getMonotonicTimeNSec
 
 -- | Randomly shuffle a list
 --   /O(N)/

--- a/Test/Framework/Utils.hs
+++ b/Test/Framework/Utils.hs
@@ -22,7 +22,11 @@ module Test.Framework.Utils where
 
 import System.Directory
 import Data.Char
+#if MIN_VERSION_base(4,11,0)
 import GHC.Clock (getMonotonicTimeNSec)
+#else
+import Data.Time.Clock.POSIX (getPOSIXTime)
+#endif
 import System.Random
 import Data.Array.IO
 import Control.Monad
@@ -150,7 +154,13 @@ measure ma =
        return (a, fromInteger (diffMicro `div` 1000))
 
 getMicroTime :: IO Integer
-getMicroTime = (`div` 1000) . fromIntegral <$> getMonotonicTimeNSec
+#if MIN_VERSION_base(4,11,0)
+getMicroTime =
+    (`div` 1000) . fromIntegral <$> getMonotonicTimeNSec
+#else
+getMicroTime =
+    floor . (* 1000000) <$> getPOSIXTime
+#endif
 
 -- | Randomly shuffle a list
 --   /O(N)/


### PR DESCRIPTION
* use `getMonotonicTimeNSec` - Thank you @sol for [spotting this](https://github.com/skogsbaer/HTF/pull/137#issuecomment-4423773194)! 
* clean up `time` dependency
* `getMonotonicTimeNSec` is in `base` 4.11 and this is incompatible with `GHC` 8.8 so added conditional logic

Tested with toy example:
```
import Test.Framework.Utils
import Control.Concurrent (threadDelay)

main :: IO ()
main = do
  t0 <- getMicroTime
  threadDelay 10000
  t1 <- getMicroTime
  putStrLn $ "getMicroTime in micro sec = " <> show (t1 - t0)

  (_, elapsed) <- measure (threadDelay 10000)
  putStrLn $ "measure in mili sec = " <> show elapsed
  ```
 that executed `cabal exec -- runghc SmokeTest.hs` produces:
  ```
getMicroTime in micro sec = 10412
measure in mili sec = 10
```
Similar numbers before change.